### PR TITLE
Fix Kustomer pagination bug

### DIFF
--- a/tap_kustomer/client.py
+++ b/tap_kustomer/client.py
@@ -5,7 +5,6 @@ import requests
 from singer import metrics, utils
 import singer
 
-API_VERSION = 'v1'
 LOGGER = singer.get_logger()
 RATE_LIMIT_REMAINING = 'x-ratelimit-remaining'
 RATE_LIMIT_RESET = 'x-ratelimit-reset'
@@ -99,7 +98,7 @@ class KustomerClient():
         self.__user_agent = user_agent
         self.__session = requests.Session()
         self.__verified = False
-        self.base_url = 'https://api.kustomerapp.com/{}'.format(API_VERSION)
+        self.base_url = 'https://api.kustomerapp.com'
 
     def __enter__(self):
         self.__verified = self.check_token()
@@ -120,7 +119,7 @@ class KustomerClient():
         headers['Accept'] = 'application/json'
         response = self.__session.get(
             # Simple endpoint that returns 1 Account record (to check API/token access):
-            url='{}/{}/'.format(self.base_url, 'users/current'),
+            url='{}/{}/'.format(self.base_url, '/v1/users/current'),
             headers=headers)
         if response.status_code != 200:
             LOGGER.error('Error status_code = %s', response.status_code)

--- a/tap_kustomer/streams.py
+++ b/tap_kustomer/streams.py
@@ -14,6 +14,7 @@
 #   bookmark_query_field: From date-time field used for filtering the query
 #   bookmark_type: Data type for bookmark, integer or datetime
 
+API_VERSION = 'v1'
 STREAMS = {
     "customers": {
         "api_method": "POST",
@@ -31,7 +32,7 @@ STREAMS = {
             "sort": [{"customer_updated_at": "asc"}],
             "queryContext": "customer"
         },
-        "path": "customers/search",
+        "path": f'{API_VERSION}/customers/search',
         "replication_method": "INCREMENTAL",
         "replication_keys": ["updated_at"],
         "bookmark_query_field": "customer_updated_at"
@@ -50,7 +51,7 @@ STREAMS = {
         },
         "replication_method": "INCREMENTAL",
         "key_properties": ["id"],
-        "path": "customers/search",
+        "path": f'{API_VERSION}/customers/search',
         "replication_keys": ["updated_at"],
         "api_method": "POST",
         "data_key": "data",
@@ -71,7 +72,7 @@ STREAMS = {
         },
         "replication_method": "INCREMENTAL",
         "key_properties": ["id"],
-        "path": "customers/search",
+        "path": f'{API_VERSION}/customers/search',
         "replication_keys": ["updated_at"],
         "api_method": "POST",
         "data_key": "data",
@@ -92,7 +93,7 @@ STREAMS = {
         },
         "replication_method": "INCREMENTAL",
         "key_properties": ["id"],
-        "path": "customers/search",
+        "path": f'{API_VERSION}/customers/search',
         "replication_keys": ["updated_at"],
         "api_method": "POST",
         "data_key": "data",
@@ -106,7 +107,7 @@ STREAMS = {
         },
         "replication_method": "INCREMENTAL",
         "key_properties": ["id"],
-        "path": "users",
+        "path": f'{API_VERSION}/users',
         "replication_keys": ["updated_at"],
         "api_method": "GET",
         "data_key": "data",
@@ -121,7 +122,7 @@ STREAMS = {
         },
         "replication_method": "INCREMENTAL",
         "key_properties": ["id"],
-        "path": "teams",
+        "path": f'{API_VERSION}/teams',
         "replication_keys": ["updated_at"],
         "api_method": "GET",
         "data_key": "data",
@@ -136,7 +137,7 @@ STREAMS = {
         },
         "replication_method": "INCREMENTAL",
         "key_properties": ["id"],
-        "path": "tags",
+        "path": f'{API_VERSION}/tags',
         "replication_keys": ["updated_at"],
         "api_method": "GET",
         "data_key": "data",
@@ -151,7 +152,7 @@ STREAMS = {
         },
         "replication_method": "INCREMENTAL",
         "key_properties": ["id"],
-        "path": "shortcuts",
+        "path": f'{API_VERSION}/shortcuts',
         "replication_keys": ["updated_at"],
         "api_method": "GET",
         "data_key": "data",
@@ -172,7 +173,7 @@ STREAMS = {
         },
         "replication_method": "INCREMENTAL",
         "key_properties": ["id"],
-        "path": "customers/search",
+        "path": f'{API_VERSION}/customers/search',
         "replication_keys": ["updated_at"],
         "api_method": "POST",
         "data_key": "data",

--- a/tap_kustomer/sync.py
+++ b/tap_kustomer/sync.py
@@ -167,7 +167,7 @@ def sync_endpoint(client,  # pylint: disable=too-many-branches, too-many-stateme
             if bookmark_query_field_to:
                 if bookmark_type == 'integer':
                     params[bookmark_query_field_to] = strftime(end_window)
-        
+
         for key, _ in endpoint_config.get('params').items():
             if key == 'page':
                 params[key] = page
@@ -222,7 +222,7 @@ def sync_endpoint(client,  # pylint: disable=too-many-branches, too-many-stateme
         # there is supposedly more pages available. Manually requesting
         # subsequent pages will return a 404 response code.
         next_page = response.get('links').get('next', None)
-        if next_page: 
+        if next_page:
             next_url = '{}{}'.format(client.base_url, next_page)
 
         # Transform data with transform_json from transform.py


### PR DESCRIPTION
Hitting a url for the first time worked fine, however hitting subsequent urls using the next links would double up on version numbers in the url. Example: `api.kustomer.com/v1/v1/customers/search`